### PR TITLE
fix: 지난 날짜에 예약, 취소 막기 + 로그아웃하면 헤더 프로필 이미지 없어지도록 수정

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -29,7 +29,7 @@ function Header() {
         </Styled.Logo>
 
         <div className="right-container">
-          {user && <Styled.ProfileImage user={user} />}
+          {isLoggedIn && user && <Styled.ProfileImage user={user} />}
 
           <MenuItem
             label={isLoggedIn ? 'Logout' : 'Login'}

--- a/src/components/Reservation/Desk/default.tsx
+++ b/src/components/Reservation/Desk/default.tsx
@@ -5,6 +5,7 @@ import Loading from '../../Loading';
 function Default({
   deskNo,
   isHovering,
+  isPassed,
   handleMouseOver,
   handleMouseOut,
   onReserveButtonClick,
@@ -13,25 +14,27 @@ function Default({
 }: {
   deskNo: number;
   isHovering: boolean;
+  isPassed: boolean;
   handleMouseOver: () => void;
   handleMouseOut: () => void;
   items?: Item[];
   onReserveButtonClick: () => void;
   isPendingCreate: boolean;
 }) {
+  const hoverActive = isHovering && !isPassed;
   return (
     <Styled.Container
       className="default"
-      $isHovering={isHovering}
+      $isHovering={hoverActive}
       onMouseOver={handleMouseOver}
       onMouseOut={handleMouseOut}
-      onClick={onReserveButtonClick}
+      onClick={hoverActive ? onReserveButtonClick : () => {}}
     >
       {isPendingCreate ? (
         <Loading />
       ) : (
         <>
-          {isHovering && (
+          {hoverActive && (
             <>
               <p className="text">자리 예약하기</p>
 
@@ -49,7 +52,7 @@ function Default({
             </>
           )}
 
-          {!isHovering && <p className="desk-no">{deskNo}</p>}
+          {!hoverActive && <p className="desk-no">{deskNo}</p>}
         </>
       )}
     </Styled.Container>

--- a/src/components/Reservation/Desk/index.tsx
+++ b/src/components/Reservation/Desk/index.tsx
@@ -9,6 +9,7 @@ function Desk({
   deskNo,
   reservation,
   myself,
+  isPassed,
   createReservation,
   cancelReservation,
   isPendingCreate,
@@ -19,6 +20,7 @@ function Desk({
   deskNo: number;
   reservation: Reservation | undefined;
   myself?: User;
+  isPassed: boolean;
   createReservation: (seatId: number) => void;
   cancelReservation: (seatId: number) => void;
   isPendingCreate: boolean;
@@ -44,6 +46,7 @@ function Desk({
       <Reserved
         isHovering={isHovering}
         isMine={isMine}
+        isPassed={isPassed}
         handleMouseOver={handleMouseOver}
         handleMouseOut={handleMouseOut}
         name={name}
@@ -62,6 +65,7 @@ function Desk({
       <Default
         deskNo={deskNo}
         isHovering={isHovering}
+        isPassed={isPassed}
         handleMouseOver={handleMouseOver}
         handleMouseOut={handleMouseOut}
         items={items}

--- a/src/components/Reservation/Desk/reserved.tsx
+++ b/src/components/Reservation/Desk/reserved.tsx
@@ -18,7 +18,7 @@ function Reserved({
   handleMouseOver: () => void;
   handleMouseOut: () => void;
   name: string;
-  team: string; // 'backend' | 'frontend' | 'design' | 'etc';
+  team: string;
   onClickCancelButton: () => void;
   isPendingCancel: boolean;
 }) {
@@ -41,7 +41,7 @@ function Reserved({
           ) : (
             <>
               <p className="name">{name}</p>
-              <p className="team">{convertTeam(team)}</p>
+              <p className="team">{team}</p>
             </>
           )}
         </>
@@ -49,20 +49,5 @@ function Reserved({
     </Styled.Container>
   );
 }
-
-const convertTeam = (team: string) => {
-  switch (team) {
-    case 'backend':
-      return '백엔드팀';
-    case 'frontend':
-      return '프론트엔드팀';
-    case 'design':
-      return '디자인팀';
-    case 'etc':
-      return '기획팀';
-    default:
-      return '소속팀 없음';
-  }
-};
 
 export default Reserved;

--- a/src/components/Reservation/Desk/reserved.tsx
+++ b/src/components/Reservation/Desk/reserved.tsx
@@ -4,6 +4,7 @@ import Styled from './index.styles';
 function Reserved({
   isHovering,
   isMine,
+  isPassed,
   handleMouseOver,
   handleMouseOut,
   name,
@@ -13,6 +14,7 @@ function Reserved({
 }: {
   isHovering: boolean;
   isMine: boolean;
+  isPassed: boolean;
   handleMouseOver: () => void;
   handleMouseOut: () => void;
   name: string;
@@ -20,20 +22,21 @@ function Reserved({
   onClickCancelButton: () => void;
   isPendingCancel: boolean;
 }) {
+  const hoverActive = isMine && isHovering && !isPassed;
   return (
     <Styled.Container
       className="reserved"
-      $isHovering={isHovering}
+      $isHovering={hoverActive}
       isMine={isMine}
       onMouseOver={handleMouseOver}
       onMouseOut={handleMouseOut}
-      onClick={onClickCancelButton}
+      onClick={hoverActive ? onClickCancelButton : () => {}}
     >
       {isPendingCancel ? (
         <Loading />
       ) : (
         <>
-          {isMine && isHovering ? (
+          {hoverActive ? (
             <p className="text">예약 취소하기</p>
           ) : (
             <>

--- a/src/components/Reservation/index.tsx
+++ b/src/components/Reservation/index.tsx
@@ -21,6 +21,7 @@ function Reservation({
 }) {
   const clickedDateString = dayjs(currentDate).format('YYYY-MM-DD');
   const { isOpen, message, openModal, closeModal } = useModal();
+  const isPassed = isBeforeToday(currentDate);
 
   const { list: seatList = [] } = useGetAllSeat() || {};
 
@@ -151,6 +152,7 @@ function Reservation({
           deskNo={deskNo}
           reservation={reservation}
           myself={myself}
+          isPassed={isPassed}
           createReservation={seat ? handleCreateReservation : () => {}}
           cancelReservation={seat ? handleCancelReservation : () => {}}
           key={i}
@@ -178,6 +180,17 @@ function Reservation({
       </CustomModal>
     </Styled.Container>
   );
+}
+
+/**
+ * 오늘 날짜보다 이전 날짜인지 확인
+ * @param date 날짜
+ * @returns
+ */
+function isBeforeToday(date: Date) {
+  const today = dayjs().startOf('day');
+  const inputDate = dayjs(date).startOf('day');
+  return inputDate.isBefore(today);
 }
 
 export default Reservation;


### PR DESCRIPTION
1. 지난 날짜에 예약, 취소 막기 (hover 막고 눌러도 요청 나가지 않도록)
2. 로그아웃하면 헤더에 프로필 이미지 없어지도록 수정