### PR TITLE
refactor: header layout 정비

### DIFF
--- a/src/components/Calendar/index.styles.tsx
+++ b/src/components/Calendar/index.styles.tsx
@@ -6,10 +6,15 @@ const Container = styled.div`
   flex-direction: column;
   background-color: #fff;
   gap: 16px;
+
+  border-radius: 24px;
+  ${media.mobile`
+    padding: 20px;
+    border-radius: 12px;
+  `};
 `;
 
 const Header = styled.div`
-  width: 100%;
   font-family: Poppins;
   font-size: 30px;
   font-weight: 600;

--- a/src/components/Notice/index.tsx
+++ b/src/components/Notice/index.tsx
@@ -9,6 +9,10 @@ const Container = styled.section`
   align-items: center;
   background-color: ${COLOR.white};
   word-break: keep-all;
+  gap: 10px;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  border-radius: 24px;
 
   ${media.mobile`
   width: 100%;
@@ -16,7 +20,6 @@ const Container = styled.section`
   font-size: 12px;
   line-height: 1.5;
   text-align: center;
-  gap: 10px;
   `};
 
   .notice-icon {
@@ -37,14 +40,16 @@ function Notice() {
 
       <div>
         <p>
-          FE 팀 매달 마지막 주 목요일 전체 출근 / BE 팀 매달 첫째 주 목요일 전체
-          출근 /
+          * FE 팀 매달 마지막 주 목요일 전체 출근 / BE 팀 매달 첫째 주 목요일
+          전체 출근
+        </p>
+        <p>
           <a
             href="https://forms.gle/SiSxK8rj38y4btVn6"
             target="_blank"
             rel="noreferrer"
           >
-            오픈베타(07-12~) 설문지
+            * 오픈베타(07-12~) 설문지
           </a>
         </p>
       </div>

--- a/src/pages/mainPage/index.styles.ts
+++ b/src/pages/mainPage/index.styles.ts
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 import { media } from '../../styles/media';
 
 const Container = styled.div`
-  background-color: #f4f4f4;
   padding: 40px 40px 80px;
   min-height: 100%;
 
@@ -27,22 +26,29 @@ const MainPageContainer = styled.div`
 `;
 
 const ContentHeader = styled.div`
+  width: 100%;
   display: flex;
-
   flex-direction: row;
-  justify-content: center;
-  align-items: center;
-  padding: 24px 16px;
-  gap: 16px;
-
-  background-color: #ffffff;
-  border-radius: 24px;
-
+  justify-content: space-between;
+  gap: 20px;
   ${media.mobile`
-    padding: 20px;
-    border-radius: 12px;
-  `};
+  justify-content: center;
+   `};
 `;
+
+const HeaderLeft = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  width: 100%;
+  height: 100%;
+  ${media.mobile`
+      display: none;
+   `};
+`;
+
+const HeaderRight = styled.div``;
 
 const ContentBody = styled.div`
   display: flex;
@@ -63,5 +69,7 @@ export default {
   Container,
   MainPageContainer,
   ContentHeader,
+  HeaderLeft,
+  HeaderRight,
   ContentBody,
 };

--- a/src/pages/mainPage/index.tsx
+++ b/src/pages/mainPage/index.tsx
@@ -42,24 +42,27 @@ function MainPage() {
       <Styled.Container>
         <Styled.MainPageContainer>
           <Styled.ContentHeader>
-            <Notice />
+            <Styled.HeaderLeft>
+              <Notice />
+            </Styled.HeaderLeft>
+            <Styled.HeaderRight>
+              <Calendar
+                todayDate={todayDate}
+                clickedDate={clickedDate}
+                baseDate={baseDate}
+                reservedDateList={reservedDateList}
+                setBaseDate={setBaseDate}
+                dayNames={dayNames}
+                weekList={weekList}
+                onDateClick={(date: Date) => {
+                  setClickedDate(date);
+                  isLoggedIn && refetchReservationListForDateRange();
+                }}
+              />
+            </Styled.HeaderRight>
           </Styled.ContentHeader>
 
           <Styled.ContentBody>
-            <Calendar
-              todayDate={todayDate}
-              clickedDate={clickedDate}
-              baseDate={baseDate}
-              reservedDateList={reservedDateList}
-              setBaseDate={setBaseDate}
-              dayNames={dayNames}
-              weekList={weekList}
-              onDateClick={(date: Date) => {
-                setClickedDate(date);
-                isLoggedIn && refetchReservationListForDateRange();
-              }}
-            />
-
             {isLoggedIn && myself && (
               <Reservation currentDate={clickedDate} myself={myself} />
             )}


### PR DESCRIPTION
- 피그마 디자인대로 각 캘린더 공지사항 컴포넌트는 둥근 하얀색 공간으로 나뉘어지게 수정
- 간이 랭킹 공간 창출
- 모바일 화면에서는 간이 랭킹공간&공지사항 안보이게 수정 ( 이 부분 어떻게 해야할지 모르겠어서 display : none 처리했습니다 )